### PR TITLE
Test against multiple versions of ember.js framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,19 @@ cache:
   directories:
     - node_modules
 
+env:
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
 before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 
@@ -19,4 +31,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - ember try $EMBER_TRY_SCENARIO test

--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,16 @@
 {
   "name": "ember-material-design",
   "dependencies": {
-    "jquery": "^1.11.1",
-    "ember": "1.11.0",
-    "ember-data": "1.0.0-beta.16.1",
-    "ember-resolver": "~0.1.15",
-    "loader.js": "ember-cli/loader.js#3.2.0",
+    "ember": "1.11.3",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.3.0",
+    "ember-data": "1.0.0-beta.16.1",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
+    "ember-qunit": "0.3.1",
     "ember-qunit-notifications": "0.0.7",
+    "ember-resolver": "~0.1.15",
+    "jquery": "^1.11.1",
+    "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "ember": "1.11.3",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.16.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.1",
     "ember-qunit-notifications": "0.0.7",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,35 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'default',
+      dependencies: { }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: {
+        'ember': 'beta'
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        'ember': 'components/ember#canary'
+      },
+      resolutions: {
+        'ember': 'canary'
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "ember-cli-sass": "3.1.0",
     "ember-cli-uglify": "1.0.1",
     "ember-code-snippet": "^1.0.1",
-    "ember-data": "1.0.0-beta.16.1",
     "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.1",
     "ember-try": "0.0.4"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "0.2.2",
+    "ember-cli": "0.2.3",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-autoprefixer": "0.3.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -28,13 +28,14 @@
     "ember-cli-google-analytics": "^1.3.2",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.9",
+    "ember-cli-qunit": "0.3.10",
     "ember-cli-sass": "3.1.0",
     "ember-cli-uglify": "1.0.1",
     "ember-code-snippet": "^1.0.1",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-export-application-global": "^1.0.2"
+    "ember-export-application-global": "^1.0.2",
+    "ember-disable-prototype-extensions": "^1.0.1",
+    "ember-try": "0.0.4"
   },
   "keywords": [
     "ember-addon",
@@ -42,7 +43,7 @@
     "material"
   ],
   "dependencies": {
-    "ember-cli-babel": "^4.0.0",
+    "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "0.7.4"
   },
   "ember-addon": {

--- a/testem.json
+++ b/testem.json
@@ -5,6 +5,7 @@
     "PhantomJS"
   ],
   "launch_in_dev": [
+    "PhantomJS",
     "Chrome"
   ]
 }


### PR DESCRIPTION
* Update ember-cli to `0.2.3`
* Configure travis-ci to run tests against framework versions in parallel (failures in canary are allowed)
* Update ember-load-initializers 
* Run tests against PhantomJS in dev, so there are no surprise failures in CI
* Bring in some critical ember.js security updates (`1.11.0` --> `1.11.3`)
