### PR TITLE
Update for Ember 2.0 Deprecation

### DIFF
--- a/app/initializers/md-layout-views.js
+++ b/app/initializers/md-layout-views.js
@@ -5,9 +5,14 @@ import HasLayout from 'ember-material-design/mixins/has-layout';
 export function initialize(/* container, application */) {
   // We want to inject the flex and layout parameters to every element
   // so we don't need to customize each view or component to add it
-  Ember.View.reopen(HasFlex, HasLayout, {
-    flex: null
-  });
+  
+  // Only reopen Ember.view if it exists. 
+  // Ember.View was deprecated in Ember 2.0, but it could be reincluded with an addon
+  if(Ember.View) {
+    Ember.View.reopen(HasFlex, HasLayout, {
+      flex: null
+    });
+  }
 
   Ember.Component.reopen(HasFlex, HasLayout, {
     flex: null


### PR DESCRIPTION
I was getting a WSOD of death, with an error saying Ember.default.View can't be found. 

Grepping around, and found another package(qunit*) that used `if (Ember.View)` to wrap their code. 

Cheers
